### PR TITLE
enable vercel speed insights

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.2.2",
+        "@vercel/speed-insights": "^1.0.10",
         "axios": "^1.6.8",
         "iron-session": "^8.0.1",
         "lodash": "^4.17.21",
@@ -613,6 +614,40 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.10.tgz",
+      "integrity": "sha512-4uzdKB0RW6Ff2FkzshzjZ+RlJfLPxgm/00i0XXgxfMPhwnnsk92YgtqsxT9OcPLdJUyVU1DqFlSWWjIQMPkh0g==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19",
+        "svelte": "^4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.2.2",
+    "@vercel/speed-insights": "^1.0.10",
     "axios": "^1.6.8",
     "iron-session": "^8.0.1",
     "lodash": "^4.17.21",

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Saira } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./global.css";
 
 const saira = Saira({
@@ -40,6 +41,7 @@ export default function HomeLayout({
       <body className={saira.className}>
         {children}
         <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
### Description:

This PR enables vercel speed insights.

### Tasks:

- [x] Include SpeedInsights component in layout

### References:

Vercel Documentation: https://vercel.com/docs/speed-insights/quickstart#add-the-speedinsights-component-to-your-app
