### PR TITLE
Fix: Revalidate cycling goal caching in 12 hours

### DIFF
--- a/web/src/app/(projects)/(cycling)/cycling.tsx
+++ b/web/src/app/(projects)/(cycling)/cycling.tsx
@@ -2,6 +2,8 @@ import { getSchedule } from "@/helpers/cyclingHelper";
 import Goal from "@/models/Goal";
 import styles from "./cycling.module.css";
 
+export const revalidate = 1000 * 60 * 60 * 12; // Revalidate this route caching in 12 hours
+
 export default async function Cycling() {
   const goal = await Goal.findOne({
     athleteId: Number(process.env.STRAVA_ADMIN_ID),

--- a/web/src/app/(services)/services.tsx
+++ b/web/src/app/(services)/services.tsx
@@ -16,7 +16,7 @@ const serviceItems = [
   {
     title: "Programming",
     description:
-      "Add an experienced hand to your engineering and design team to get work done with the highest quality standards.",
+      "Add an experienced hand to your engineering and design teams to get work done with the highest quality standards.",
   },
   {
     title: "Consulting",


### PR DESCRIPTION
### Description:

This PR fixes the caching issue related to strava goals only getting updated on new deployment.

### Tasks:

- [ ] Add cache revalidation

### References:

Documentation: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
