### PR TITLE
Fix: Move cache settings to page component

### DIFF
--- a/web/src/app/(projects)/(cycling)/cycling.tsx
+++ b/web/src/app/(projects)/(cycling)/cycling.tsx
@@ -2,8 +2,6 @@ import { getSchedule } from "@/helpers/cyclingHelper";
 import Goal from "@/models/Goal";
 import styles from "./cycling.module.css";
 
-export const revalidate = 1000 * 60 * 60 * 12; // Revalidate this route caching in 12 hours
-
 export default async function Cycling() {
   const goal = await Goal.findOne({
     athleteId: Number(process.env.STRAVA_ADMIN_ID),

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,6 +5,8 @@ import ExperienceSection from "./(experience)/experience";
 import ProjectsSection from "./(projects)/projects";
 import Header from "./(header)/header";
 
+export const revalidate = 1000 * 60 * 60 * 12; // Revalidate this route caching in 12 hours
+
 export default function Home() {
   return (
     <>


### PR DESCRIPTION
### Description:

This PR move the cache settings to the correct component file. As documentation, it must be in `layout.tsx | page.tsx | route.ts`

### Tasks:

- [x] Move cache settings to page.tsx

### References:

Documentation: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
